### PR TITLE
Authentication reimplemented to work well with ConnectionPool and with multiple DBs

### DIFF
--- a/tests/mongod.py
+++ b/tests/mongod.py
@@ -29,6 +29,7 @@ class Mongod(object):
                 '--dbpath', str(self.dbpath),
                 '--noprealloc', '--nojournal',
                 '--smallfiles', '--nssize', '1',
+                '--nohttpinterface',
                 ]
 
         if self.auth: args.append('--auth')

--- a/tests/mongod.py
+++ b/tests/mongod.py
@@ -1,0 +1,73 @@
+from twisted.internet import defer, reactor
+from twisted.internet.error import ProcessDone
+
+
+class Mongod(object):
+
+    # FIXME: this message might change in future versions of MongoDB
+    # but waiting for this message is faster than pinging tcp port
+    # so leaving this for now
+    success_message = 'waiting for connections on port'
+
+    def __init__(self, dbpath, port=27017, auth=False):
+        self.__proc = None
+        self.__notify_waiting = []
+        self.__notify_stop = []
+        self.__output = ''
+        self.__end_reason = None
+
+        self.dbpath = dbpath
+        self.port = port
+        self.auth = auth
+
+    def start(self):
+        d = defer.Deferred()
+        self.__notify_waiting.append(d)
+
+        args = ['mongod',
+                '--port', str(self.port),
+                '--dbpath', str(self.dbpath),
+                '--noprealloc', '--nojournal',
+                '--smallfiles', '--nssize', '1',
+                ]
+
+        if self.auth: args.append('--auth')
+
+        self.__proc = reactor.spawnProcess(self, 'mongod', args)
+        return d
+
+
+    def stop(self):
+        if self.__end_reason is None:
+            if self.__proc and self.__proc.pid:
+                d = defer.Deferred()
+                self.__notify_stop.append(d)
+                self.__proc.signalProcess('INT')
+                return d
+            else:
+                return defer.fail('Not started yet')
+        else:
+            if self.__end_reason.check(ProcessDone):
+                return defer.succeed(None)
+            else:
+                return defer.fail(self.__end_reason)
+
+    def makeConnection(self, process): pass
+    def childConnectionLost(self, child_fd): pass
+    def processExited(self, reason): pass
+
+    def childDataReceived(self, child_fd, data):
+        self.__output += data
+        if self.success_message in self.__output:
+            defs, self.__notify_waiting = self.__notify_waiting, []
+            for d in defs:
+                d.callback(None)
+
+    def processEnded(self, reason):
+        self.__end_reason = reason
+        defs, self.__notify_stop, self.__notify_waiting = self.__notify_stop + self.__notify_waiting, [], []
+        for d in defs:
+            if reason.check(ProcessDone):
+                d.callback(None)
+            else:
+                d.errback(reason)

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -1,0 +1,198 @@
+# coding: utf-8
+# Copyright 2015 Ilya Skriblovsky
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import txmongo
+from bson.son import SON
+from pymongo.errors import OperationFailure
+from twisted.trial import unittest
+from twisted.internet import base, defer
+
+from txmongo.protocol import MongoAuthenticationError
+
+base.DelayedCall.debug = True
+
+mongo_host = 'localhost'
+mongo_uri = 'mongodb://{0}/'.format(mongo_host)
+
+
+class TestMongoAuth(unittest.TestCase):
+    db1 = 'authtest1'
+    db2 = 'authtest2'
+    coll = 'mycol'
+
+    login1 = 'user1'
+    password1 = 'pwd1'
+
+    login2 = 'user2'
+    password2 = 'pwd2'
+
+    ua_login = 'useradmin'
+    ua_password = 'useradminpwd'
+
+
+    def __get_connection(self, pool_size=1):
+        return txmongo.connection.ConnectionPool(mongo_uri, pool_size)
+
+
+
+    @defer.inlineCallbacks
+    def createUserAdmin(self):
+        conn = self.__get_connection()
+
+        create_user = SON({'createUser': self.ua_login})
+        create_user.update({ 'pwd': self.ua_password, 'roles': [ { 'role': 'userAdminAnyDatabase', 'db': 'admin' } ] })
+        r = yield conn['admin']['$cmd'].find_one(create_user)
+
+        yield conn.disconnect()
+
+    @defer.inlineCallbacks
+    def createDBUsers(self):
+        conn = self.__get_connection()
+        yield conn['admin'].authenticate(self.ua_login, self.ua_password)
+
+        create_user = SON({'createUser': self.login1})
+        create_user.update({ 'pwd': self.password1, 'roles': [ { 'role': 'readWrite', 'db': self.db1 } ] })
+        r = yield conn[self.db1]['$cmd'].find_one(create_user)
+
+        create_user = SON({'createUser': self.login2})
+        create_user.update({ 'pwd': self.password2, 'roles': [ { 'role': 'readWrite', 'db': self.db2 } ] })
+        r = yield conn[self.db2]['$cmd'].find_one(create_user)
+
+        yield conn.disconnect()
+
+
+    @defer.inlineCallbacks
+    def setUp(self):
+        yield self.createUserAdmin()
+        yield self.createDBUsers()
+
+
+    @defer.inlineCallbacks
+    def tearDown(self):
+        conn = self.__get_connection()
+        yield conn['admin'].authenticate(self.ua_login, self.ua_password)
+        yield conn[self.db1].authenticate(self.login1, self.password1)
+        yield conn[self.db2].authenticate(self.login2, self.password2)
+
+        yield conn[self.db1][self.coll].drop()
+        yield conn[self.db2][self.coll].drop()
+        yield conn[self.db1]['$cmd'].find_one({'dropUser': self.login1})
+        yield conn[self.db2]['$cmd'].find_one({'dropUser': self.login2})
+        yield conn['admin']['$cmd'].find_one({'dropUser': self.ua_login})
+        yield conn.disconnect()
+
+
+
+    @defer.inlineCallbacks
+    def test_AuthConnectionPool(self):
+        pool_size = 2
+
+        conn = self.__get_connection(pool_size)
+        db = conn[self.db1]
+        coll = db[self.coll]
+
+        try:
+            yield db.authenticate(self.login1, self.password1)
+
+            n = pool_size + 1
+
+            yield defer.gatherResults(coll.insert({'x': 42}) for x in xrange(n))
+
+            cnt = yield coll.count()
+            self.assertEqual(cnt, n)
+        finally:
+            yield conn.disconnect()
+
+
+    @defer.inlineCallbacks
+    def test_AuthConnectionPoolUri(self):
+        pool_size = 5
+
+        conn = txmongo.connection.ConnectionPool(
+            'mongodb://{0}:{1}@{2}/{3}'.format(self.login1, self.password1, mongo_host, self.db1)
+        )
+        db = conn.get_default_database()
+        coll = db[self.coll]
+
+        n = pool_size + 1
+
+        try:
+            yield defer.gatherResults(coll.insert({'x': 42}) for x in xrange(n))
+
+            cnt = yield coll.count()
+            self.assertEqual(cnt, n)
+        finally:
+            yield conn.disconnect()
+
+
+    @defer.inlineCallbacks
+    def test_AuthFailAtStartup(self):
+        conn = self.__get_connection()
+        db = conn[self.db1]
+
+        try:
+            db.authenticate(self.login1, self.password1 + 'x')
+            yield self.assertFailure(conn[self.db1][self.coll].find_one(), OperationFailure)
+        finally:
+            yield conn.disconnect()
+
+
+    @defer.inlineCallbacks
+    def test_AuthFailAtRuntime(self):
+        conn = self.__get_connection()
+        db = conn[self.db1]
+
+        try:
+            yield self.assertFailure(conn[self.db1][self.coll].find_one(), OperationFailure)
+            yield self.assertFailure(db.authenticate(self.login1, self.password1 + 'x'), MongoAuthenticationError)
+            yield self.assertFailure(conn[self.db1][self.coll].find_one(), OperationFailure)
+        finally:
+            yield conn.disconnect()
+
+
+    @defer.inlineCallbacks
+    def test_AuthOnTwoDBsParallel(self):
+        conn = self.__get_connection()
+
+        try:
+            yield self.assertFailure(conn[self.db1][self.coll].find_one(), OperationFailure)
+
+            yield defer.gatherResults([
+                conn[self.db1].authenticate(self.login1, self.password1),
+                conn[self.db2].authenticate(self.login2, self.password2),
+            ])
+
+            yield defer.gatherResults([
+                conn[self.db1][self.coll].insert({'x': 42}),
+                conn[self.db2][self.coll].insert({'x': 42}),
+            ])
+        finally:
+            yield conn.disconnect()
+
+
+    @defer.inlineCallbacks
+    def test_AuthOnTwoDBsSequential(self):
+        conn = self.__get_connection()
+
+        try:
+            yield self.assertFailure(conn[self.db1][self.coll].find_one(), OperationFailure)
+
+            yield conn[self.db1].authenticate(self.login1, self.password1)
+            yield conn[self.db1][self.coll].find_one()
+
+            yield conn[self.db2].authenticate(self.login2, self.password2)
+            yield conn[self.db2][self.coll].find_one()
+        finally:
+            yield conn.disconnect()

--- a/txmongo/collection.py
+++ b/txmongo/collection.py
@@ -119,10 +119,7 @@ class Collection(object):
                     else:
                         spec['$' + k] = v
 
-        if self._database._authenticated:
-            proto = yield self._database.connection.get_authenticated_protocol(self._database)
-        else:
-            proto = yield self._database.connection.getprotocol()
+        proto = yield self._database.connection.getprotocol()
 
         flags = kwargs.get('flags', 0)
         query = Query(flags=flags, collection=str(self),
@@ -313,10 +310,7 @@ class Collection(object):
         flags = kwargs.get('flags', 0)
         insert = Insert(flags=flags, collection=str(self), documents=docs)
 
-        if self._database._authenticated:
-            proto = yield self._database.connection.get_authenticated_protocol(self._database)
-        else:
-            proto = yield self._database.connection.getprotocol()
+        proto = yield self._database.connection.getprotocol()
 
         proto.send_INSERT(insert)
 
@@ -345,10 +339,7 @@ class Collection(object):
         document = bson.BSON.encode(document)
         update = Update(flags=flags, collection=str(self),
                         selector=spec, update=document)
-        if self._database._authenticated:
-            proto = yield self._database.connection.get_authenticated_protocol(self._database)
-        else:
-            proto = yield self._database.connection.getprotocol()
+        proto = yield self._database.connection.getprotocol()
 
         proto.send_UPDATE(update)
 
@@ -379,10 +370,7 @@ class Collection(object):
 
         spec = bson.BSON.encode(spec)
         delete = Delete(flags=flags, collection=str(self), selector=spec)
-        if self._database._authenticated:
-            proto = yield self._database.connection.get_authenticated_protocol(self._database)
-        else:
-            proto = yield self._database.connection.getprotocol()
+        proto = yield self._database.connection.getprotocol()
 
         proto.send_DELETE(delete)
 

--- a/txmongo/database.py
+++ b/txmongo/database.py
@@ -10,7 +10,6 @@ from txmongo.collection import Collection
 
 class Database(object):
     __factory = None
-    _authenticated = False
 
     def __init__(self, factory, database_name):
         self.__factory = factory
@@ -98,4 +97,4 @@ class Database(object):
         """
         Authenticating
         """
-        yield self.connection.authenticate_with_nonce(self, name, password)
+        yield self.connection.authenticate(self, name, password)


### PR DESCRIPTION
Hi!

The current implementation of authentication is broken in several use cases:

* It is not reenterant and this leads to bugs with ConnectionPool when pool_size > 1. In such case ConnectionPool.authenticate_with_nonce() might be called multiple times simultaneously and race-condition occurs because 'getnonce' and 'authenticate' MongoDB commands cannot be mixed up.

* It makes assumption that authentication on some DB is only required when accessing this DB. But MongoDB allows user from DB1 to have permissions on DB2.

I've reworked all auth-related stuff and added some unit tests, some of them are failing on master branch.

*Please note that unit tests in test_auth.py require your local MongoDB to have auth=true, no configured users and localhost exception enabled.*