### PR TITLE
Fixed regression on Twisted<=13.1.0

### DIFF
--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -142,7 +142,7 @@ class TestMongoAuth(unittest.TestCase):
 
             n = pool_size + 1
 
-            yield defer.gatherResults(coll.insert({'x': 42}) for x in xrange(n))
+            yield defer.gatherResults([coll.insert({'x': 42}) for x in xrange(n)])
 
             cnt = yield coll.count()
             self.assertEqual(cnt, n)
@@ -163,7 +163,7 @@ class TestMongoAuth(unittest.TestCase):
         n = pool_size + 1
 
         try:
-            yield defer.gatherResults(coll.insert({'x': 42}) for x in xrange(n))
+            yield defer.gatherResults([coll.insert({'x': 42}) for x in xrange(n)])
 
             cnt = yield coll.count()
             self.assertEqual(cnt, n)

--- a/txmongo/connection.py
+++ b/txmongo/connection.py
@@ -206,8 +206,8 @@ class _Connection(ReconnectingClientFactory):
     @defer.inlineCallbacks
     def _auth_proto(self, proto):
         yield defer.DeferredList(
-            (proto.authenticate(database, username, password)
-            for database, (username, password) in self.__auth_creds.iteritems()),
+            [proto.authenticate(database, username, password)
+             for database, (username, password) in self.__auth_creds.iteritems()],
             consumeErrors=True
         )
 
@@ -288,7 +288,7 @@ class ConnectionPool(object):
     def authenticate(self, database, username, password):
         try:
             yield defer.gatherResults(
-                (connection.authenticate(database, username, password) for connection in self.__pool),
+                [connection.authenticate(database, username, password) for connection in self.__pool],
                 consumeErrors=True
             )
         except defer.FirstError as e:


### PR DESCRIPTION
Recent authentication-related changes broke compatibility with Twisted ≤ 13.1.0 because DeferredList doesn't support generators.

Issue reported as #75 