### PR TITLE
find() as wrapper around fixed find_with_cursor()

### DIFF
--- a/tests/test_queries.py
+++ b/tests/test_queries.py
@@ -76,6 +76,25 @@ class TestMongoQueries(unittest.TestCase):
         self.assertEqual(total, 750)
 
     @defer.inlineCallbacks
+    def test_FindWithCursorLimit(self):
+        yield self.coll.insert([{'v': i} for i in range(750)], safe=True)
+
+        docs, d = yield self.coll.find_with_cursor(limit=150)
+        total = 0
+        while docs:
+            total += len(docs)
+            docs, d = yield d
+        self.assertEqual(total, 150)
+
+        # Same using find(cursor=True)
+        docs, d = yield self.coll.find(limit=150, cursor=True)
+        total = 0
+        while docs:
+            total += len(docs)
+            docs, d = yield d
+        self.assertEqual(total, 150)
+
+    @defer.inlineCallbacks
     def test_LargeData(self):
         yield self.coll.insert([{'v': ' '*(2**19)} for _ in range(4)], safe=True)
         res = yield self.coll.find()

--- a/tests/test_queries.py
+++ b/tests/test_queries.py
@@ -23,6 +23,16 @@ mongo_host = "localhost"
 mongo_port = 27017
 
 
+class _CallCounter(object):
+    def __init__(self, original):
+        self.call_count = 0
+        self.original = original
+
+    def __call__(self, this, *args, **kwargs):
+        self.call_count += 1
+        return self.original(this, *args, **kwargs)
+
+
 class TestMongoQueries(unittest.TestCase):
 
     timeout = 5
@@ -113,42 +123,68 @@ class TestMongoQueries(unittest.TestCase):
         res = yield self.coll.group(keys, initial, reduce_, cond, final)
         self.assertEqual(len(res["retval"]), 1)
 
+    def __make_big_object(self):
+        return {"_id": ObjectId(), 'x': 'a' * 1000}
+
     @defer.inlineCallbacks
     def test_CursorClosing(self):
-        def make_object():
-            return {"_id": ObjectId(), 'x': 'a' * 1000}
-
         # Calculate number of objects in 4mb batch
-        obj_count_4mb = 4 * 1024**2 / len(BSON.encode(make_object())) + 1
+        obj_count_4mb = 4 * 1024**2 / len(BSON.encode(self.__make_big_object())) + 1
 
         first_batch = 5
-        yield self.coll.insert([make_object() for _ in range(first_batch + obj_count_4mb)])
-        yield self.coll.find(limit=first_batch)
+        yield self.coll.insert([self.__make_big_object() for _ in range(first_batch + obj_count_4mb)])
+        result = yield self.coll.find(limit=first_batch)
+
+        self.assertEqual(len(result), 5)
+
+        status = yield self.db["$cmd"].find_one({"serverStatus": 1})
+        self.assertEqual(status["metrics"]["cursor"]["open"]["total"], 0)
+
+    @defer.inlineCallbacks
+    def test_CursorClosingWithCursor(self):
+        # Calculate number of objects in 4mb batch
+        obj_count_4mb = 4 * 1024**2 / len(BSON.encode(self.__make_big_object())) + 1
+
+        first_batch = 5
+        yield self.coll.insert([self.__make_big_object() for _ in range(first_batch + obj_count_4mb)])
+
+        result = []
+        docs, dfr = yield self.coll.find_with_cursor({}, limit=first_batch)
+        while docs:
+            result.extend(docs)
+            docs, dfr = yield dfr
+
+        self.assertEqual(len(result), 5)
 
         status = yield self.db["$cmd"].find_one({"serverStatus": 1})
         self.assertEqual(status["metrics"]["cursor"]["open"]["total"], 0)
 
     @defer.inlineCallbacks
     def test_GetMoreCount(self):
-        class CallCounter(object):
-            def __init__(self, original):
-                self.call_count = 0
-                self.original = original
+        counter = _CallCounter(MongoClientProtocol.send_GETMORE)
+        self.patch(MongoClientProtocol, 'send_GETMORE', counter)
 
-            def __call__(self, this, *args, **kwargs):
-                self.call_count += 1
-                return self.original(this, *args, **kwargs)
+        yield self.coll.insert([{'x': 42} for _ in range(20)])
+        result = yield self.coll.find({}, limit=10)
 
-        counter = CallCounter(MongoClientProtocol.send_GETMORE)
-        MongoClientProtocol.send_GETMORE = counter
+        self.assertEqual(len(result), 10)
+        self.assertEqual(counter.call_count, 0)
 
-        try:
-            yield self.coll.insert([{'x': 42} for _ in range(20)])
-            yield self.coll.find({}, limit=10)
+    @defer.inlineCallbacks
+    def test_GetMoreCountWithCursor(self):
+        counter = _CallCounter(MongoClientProtocol.send_GETMORE)
+        self.patch(MongoClientProtocol, 'send_GETMORE', counter)
 
-            self.assertEqual(counter.call_count, 0)
-        finally:
-            MongoClientProtocol.send_GETMORE = counter.original
+        yield self.coll.insert([{'x': 42} for _ in range(20)])
+
+        result = []
+        docs, dfr = yield self.coll.find_with_cursor({}, limit=5)
+        while docs:
+            result.extend(docs)
+            docs, dfr = yield dfr
+
+        self.assertEqual(len(result), 5)
+        self.assertEqual(counter.call_count, 0)
 
     @defer.inlineCallbacks
     def tearDown(self):

--- a/txmongo/collection.py
+++ b/txmongo/collection.py
@@ -100,8 +100,8 @@ class Collection(object):
     @defer.inlineCallbacks
     def find(self, spec=None, skip=0, limit=0, fields=None, filter=None, cursor=False, **kwargs):
         if cursor:
-            out = yield self.find_with_cursor(spec=spec, skip=skip, fields=fields, filter=filter,
-                                              **kwargs)
+            out = yield self.find_with_cursor(spec=spec, skip=skip, limit=limit,
+                                              fields=fields, filter=filter, **kwargs)
             defer.returnValue(out)
         if spec is None:
             spec = SON()


### PR DESCRIPTION
I have fixed same problems with `limit=` in `find_with_cursor()` as 477f34a1190b272265f1702e3e11875a58457125 fixed for `find()`

After that I noticed that `find()` and `find_with_cursor()` are almost identical while `find_with_cursor()` is the superset of `find()`. So, 539ca559b9be06715f9094c61da45cb068601538 replaces `find()` implementation with simple code that unwinds result of `find_with_cursor()`.

I don't see any way compatibility or something might be broken because they do literally the same, including error-handling (i.e. absense of it :) ).